### PR TITLE
Refactor: Use ModelLp as a LpProblem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+Next release
+------------
+* Change in API: call `model.constraints.len()` and `model.variables.len()` instead
+of accessing the now removed underlying `LpProblem`.
+* Benchmarks: within noise range from previous baseline.
+* Model implements the trait
+[`Problem`](https://github.com/jcavat/rust-lp-modeler/blob/master/src/dsl/problem.rs#L26).
+* Model implements `Into<LpProblem>`.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ println!(
     "Model has {:?} constraints",
     &model.problem.constraints.len()
 );
-println!("Model has {:?} variables", &model.problem.variables().len());
+println!("Model has {:?} variables", &model.variables().len());
 ```
 _Output_
 ```

--- a/examples/ecoli.rs
+++ b/examples/ecoli.rs
@@ -8,10 +8,7 @@ fn main() {
     let file_str = std::fs::read_to_string("examples/EcoliCore.xml").unwrap();
     let model = ModelLP::from_str(&file_str).unwrap();
     // println!("{:?}", model.metabolites_lp);
-    println!(
-        "Model has {:?} constraints",
-        &model.constraints.len()
-    );
+    println!("Model has {:?} constraints", &model.constraints.len());
     println!("Model has {:?} variables", &model.variables.len());
     for (name, val) in model.optimize().unwrap().iter() {
         println!("{} = {}", name, val)

--- a/examples/ecoli.rs
+++ b/examples/ecoli.rs
@@ -10,9 +10,9 @@ fn main() {
     // println!("{:?}", model.metabolites_lp);
     println!(
         "Model has {:?} constraints",
-        &model.problem.constraints.len()
+        &model.constraints.len()
     );
-    println!("Model has {:?} variables", &model.problem.variables().len());
+    println!("Model has {:?} variables", &model.variables.len());
     for (name, val) in model.optimize().unwrap().iter() {
         println!("{} = {}", name, val)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ impl AddAssign<LpConstraint> for ModelLP {
 
 impl AddAssign<LpExpression> for ModelLP {
     fn add_assign(&mut self, _rhs: LpExpression) {
-        self.add_objective_expression(&_rhs.into());
+        self.add_objective_expression(&_rhs);
     }
 }
 
@@ -207,7 +207,7 @@ impl From<Model> for ModelLP {
 }
 
 impl From<&ModelLP> for LpProblem {
-    fn from(model: &ModelLP) -> LpProblem  {
+    fn from(model: &ModelLP) -> LpProblem {
         LpProblem {
             // TODO: from sbml
             name: "COBRA model",


### PR DESCRIPTION
* [x] Related to #1 
* [x] CHANGELOG.md updated

### Description
Treat `ModelLp` as a `LpProblem.` This way, future implementations of flux analysis methods can target a general `LpProblem`.

### Implementation
* Implement the trait [Problem](https://github.com/jcavat/rust-lp-modeler/blob/master/src/dsl/problem.rs#L26) for `ModelLP`.
* Implement [`std::ops::AddAsign`](https://doc.rust-lang.org/std/ops/trait.AddAssign.html) for `ModelLP` += `LpExpression` and `LpConstraint`.
* Implement `Into<LpProblem>` for `ModelLP`.

With these changes, the ModelLP shares the `+=` API with `LpProblem` and can be optimized (with an implicit conversion) by a solver.