### PR TITLE
CHORE: replace lp-modeler with good_lp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 [dependencies]
 rust_sbml = { version="0.5.1", default_features=false }
 good_lp = { version="0.4", default-features=false }
-uuid = { version="0.7.4", features=["v4"]}
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "./src/docs-header.html" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 rust_sbml = { version="0.5.1", default_features=false }
-lp-modeler = "0.4.3"
+good_lp = { version="0.4", default-features=false }
 uuid = { version="0.7.4", features=["v4"]}
 
 [package.metadata.docs.rs]
@@ -21,6 +21,7 @@ rustdoc-args = [ "--html-in-header", "./src/docs-header.html" ]
 
 [dev-dependencies]
 criterion = "0.3.3"
+good_lp = "0.4"
 
 [[bench]]
 name = "formulate_from_sbml"

--- a/benches/formulate_from_sbml.rs
+++ b/benches/formulate_from_sbml.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
+extern crate good_lp;
 extern crate kair;
 
-use good_lp::coin_cbc;
+use good_lp::{coin_cbc, constraint, Expression, ProblemVariables, SolverModel};
 use kair::{flux_analysis::fba, ModelLP};
-
 use std::str::FromStr;
 
 fn read_ecoli() {
@@ -12,10 +12,25 @@ fn read_ecoli() {
     ModelLP::from_str(file_str).unwrap();
 }
 
+fn read_recon1() {
+    let file_str = include_str!("../tests/RECON1.xml");
+    let mut model = ModelLP::from_str(file_str).unwrap();
+    let mut problem = ProblemVariables::new();
+    model.populate_model(&mut problem);
+    let mut problem = problem.maximise(model.get_objective()).using(coin_cbc);
+    for (_, cons) in model.stoichiometry.iter() {
+        problem.add_constraint(constraint::eq(cons.iter().sum::<Expression>(), 0f32));
+    }
+}
+
 fn optimize_ecoli() {
     let file_str = include_str!("../tests/EcoliCore.xml");
-    let model = ModelLP::from_str(file_str).unwrap();
-    fba(model, coin_cbc).unwrap();
+    let mut model = ModelLP::from_str(file_str).unwrap();
+    fba(&mut model, coin_cbc).unwrap();
+}
+
+fn create_big_lp_benchmark(c: &mut Criterion) {
+    c.bench_function("Populate Recon1", |b| b.iter(read_recon1));
 }
 
 fn create_lp_benchmark(c: &mut Criterion) {
@@ -26,5 +41,11 @@ fn optimize_benchmark(c: &mut Criterion) {
     c.bench_function("Optimize E. coli core", |b| b.iter(optimize_ecoli));
 }
 
-criterion_group!(benches, optimize_benchmark, create_lp_benchmark);
+criterion_group!(
+    benches,
+    create_lp_benchmark,
+    optimize_benchmark,
+    create_big_lp_benchmark,
+);
+
 criterion_main!(benches);

--- a/benches/formulate_from_sbml.rs
+++ b/benches/formulate_from_sbml.rs
@@ -2,7 +2,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 extern crate kair;
 
-use kair::ModelLP;
+use good_lp::coin_cbc;
+use kair::{flux_analysis::fba, ModelLP};
+
 use std::str::FromStr;
 
 fn read_ecoli() {
@@ -13,7 +15,7 @@ fn read_ecoli() {
 fn optimize_ecoli() {
     let file_str = include_str!("../tests/EcoliCore.xml");
     let model = ModelLP::from_str(file_str).unwrap();
-    model.optimize().unwrap();
+    fba(model, coin_cbc).unwrap();
 }
 
 fn create_lp_benchmark(c: &mut Criterion) {

--- a/examples/ecoli.rs
+++ b/examples/ecoli.rs
@@ -1,15 +1,15 @@
-extern crate kair;
 extern crate good_lp;
+extern crate kair;
 
-use kair::{ModelLP, flux_analysis::fba};
 use good_lp::coin_cbc;
+use kair::{flux_analysis::fba, ModelLP};
 use std::str::FromStr;
 
 fn main() {
     let file_str = std::fs::read_to_string("examples/EcoliCore.xml").unwrap();
-    let model = ModelLP::from_str(&file_str).unwrap();
+    let mut model = ModelLP::from_str(&file_str).unwrap();
     // println!("{:?}", model.metabolites_lp);
-    for (name, val) in fba(model, coin_cbc).unwrap().iter() {
+    for (name, val) in fba(&mut model, coin_cbc).unwrap().iter() {
         println!("{} = {}", name, val)
     }
 }

--- a/examples/ecoli.rs
+++ b/examples/ecoli.rs
@@ -1,19 +1,15 @@
 extern crate kair;
-extern crate lp_modeler;
+extern crate good_lp;
 
-use kair::ModelLP;
+use kair::{ModelLP, flux_analysis::fba};
+use good_lp::coin_cbc;
 use std::str::FromStr;
 
 fn main() {
     let file_str = std::fs::read_to_string("examples/EcoliCore.xml").unwrap();
     let model = ModelLP::from_str(&file_str).unwrap();
     // println!("{:?}", model.metabolites_lp);
-    println!(
-        "Model has {:?} constraints and {:?} variables",
-        &model.constraints.len(),
-        &model.variables.len()
-    );
-    for (name, val) in model.optimize().unwrap().iter() {
+    for (name, val) in fba(model, coin_cbc).unwrap().iter() {
         println!("{} = {}", name, val)
     }
 }

--- a/src/flux_analysis.rs
+++ b/src/flux_analysis.rs
@@ -1,6 +1,6 @@
 //! COBRA methods that take an LpProblem and a Solver
 use crate::ModelLP;
-use good_lp::{constraint, solvers::Solver, Expression, ProblemVariables, Solution, SolverModel};
+use good_lp::{solvers::Solver, ProblemVariables, Solution, SolverModel};
 
 use std::collections::HashMap;
 
@@ -30,9 +30,7 @@ pub fn fba<S: Solver>(
     let mut problem = ProblemVariables::new();
     model.populate_model(&mut problem);
     let mut problem = problem.maximise(model.get_objective()).using(solver);
-    for (_, cons) in model.stoichiometry.iter() {
-        problem.add_constraint(constraint::eq(cons.iter().sum::<Expression>(), 0f32));
-    }
+    model.add_constraints::<S>(&mut problem);
     let solution = problem.solve().unwrap();
     Ok(model
         .variables

--- a/src/flux_analysis.rs
+++ b/src/flux_analysis.rs
@@ -1,5 +1,6 @@
 //! COBRA methods that take an LpProblem and a Solver
-use lp_modeler::solvers::SolverTrait;
+use crate::ModelLP;
+use good_lp::{constraint, solvers::Solver, Expression, ProblemVariables, Solution, SolverModel};
 
 use std::collections::HashMap;
 
@@ -10,7 +11,7 @@ use std::collections::HashMap;
 /// ```
 /// use kair::{ModelLP, fba};
 /// use std::{str::FromStr, convert::Into};
-/// use lp_modeler::solvers::CbcSolver;
+/// use good_lp::default_solver;
 ///
 /// # use std::{fs::File, io::{BufReader, prelude::*}};
 ///
@@ -19,13 +20,23 @@ use std::collections::HashMap;
 /// # let mut contents = String::new();
 /// # buf_reader.read_to_string(&mut contents).unwrap();
 /// // contents is a &str containing a SBML document
-/// let model = &ModelLP::from_str(&contents).unwrap();
-/// println!("{:?}", fba(&model.into(), CbcSolver::new()).unwrap())
+/// let model = ModelLP::from_str(&contents).unwrap();
+/// println!("{:?}", fba(model, default_solver).unwrap())
 /// ```
-pub fn fba<T: SolverTrait>(
-    problem: &T::P,
-    solver: T,
-) -> Result<HashMap<String, f32>, Box<dyn std::error::Error>> {
-    let solution = solver.run(problem)?;
-    Ok(solution.results)
+pub fn fba<S: Solver>(
+    mut model: ModelLP,
+    solver: S,
+) -> Result<HashMap<String, f64>, Box<dyn std::error::Error>> {
+    let mut problem = ProblemVariables::new();
+    model.populate_model(&mut problem);
+    let mut problem = problem.maximise(model.get_objective()).using(solver);
+    for (_, cons) in model.stoichiometry.iter() {
+        problem.add_constraint(constraint::eq(cons.iter().sum::<Expression>(), 0f32));
+    }
+    let solution = problem.solve().unwrap();
+    Ok(model
+        .variables
+        .iter()
+        .map(|(id, var)| (id.clone(), solution.value(*var)))
+        .collect())
 }

--- a/src/flux_analysis.rs
+++ b/src/flux_analysis.rs
@@ -20,11 +20,11 @@ use std::collections::HashMap;
 /// # let mut contents = String::new();
 /// # buf_reader.read_to_string(&mut contents).unwrap();
 /// // contents is a &str containing a SBML document
-/// let model = ModelLP::from_str(&contents).unwrap();
-/// println!("{:?}", fba(model, default_solver).unwrap())
+/// let mut model = ModelLP::from_str(&contents).unwrap();
+/// println!("{:?}", fba(&mut model, default_solver).unwrap())
 /// ```
 pub fn fba<S: Solver>(
-    mut model: ModelLP,
+    model: &mut ModelLP,
     solver: S,
 ) -> Result<HashMap<String, f64>, Box<dyn std::error::Error>> {
     let mut problem = ProblemVariables::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@
 //! let mut buf_reader = BufReader::new(file);
 //! let mut contents = String::new();
 //! buf_reader.read_to_string(&mut contents).unwrap();
-//! let model = ModelLP::from_str(&contents).unwrap();
-//! for (name, val) in fba(model, default_solver).unwrap().iter() {
+//! let mut model = ModelLP::from_str(&contents).unwrap();
+//! for (name, val) in fba(&mut model, default_solver).unwrap().iter() {
 //!     println!("{} = {}", name, val)
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub mod flux_analysis;
 pub use flux_analysis::fba;
 
 use good_lp::{
-    constraint, variable, Constraint, Expression, ProblemVariables, Solver, SolverModel, Variable,
+    constraint, variable, Expression, ProblemVariables, Solver, SolverModel, Variable,
 };
 use rust_sbml::{Model, Parameter, Reaction, Species, SpeciesReference};
 
@@ -74,9 +74,8 @@ pub struct ModelLP {
     pub config: HashMap<String, Parameter>,
     /// Reaction id to be used as the objective in the LP problem
     pub objective: String,
-    stoichiometry: HashMap<String, Vec<Expression>>,
-    /// Parsed from the stoichiometry matrix
-    pub constraints: Vec<Constraint>,
+    /// Parsed stoichiometry matrix
+    pub stoichiometry: HashMap<String, Vec<Expression>>,
 }
 
 /// Indicate that the struct can be translated to a flux balance variable (generally, reactions)
@@ -150,7 +149,7 @@ impl ModelLP {
             }
     }
     /// Build LP problem as an FBA formulation.
-    fn populate_model(&mut self, problem: &mut ProblemVariables) {
+    pub fn populate_model(&mut self, problem: &mut ProblemVariables) {
         self.add_vars(problem);
         let mut stoichiometry = HashMap::<String, Vec<Expression>>::new();
         // Build a constraint (stoichiometry) table metabolites x reactions.
@@ -238,7 +237,6 @@ impl From<Model> for ModelLP {
             config,
             objective,
             stoichiometry: HashMap::<_, _>::new(),
-            constraints: Vec::<_>::new(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,7 @@ pub mod flux_analysis;
 
 pub use flux_analysis::fba;
 
-use good_lp::{
-    constraint, variable, Expression, ProblemVariables, Solver, SolverModel, Variable,
-};
+use good_lp::{constraint, variable, Expression, ProblemVariables, Solver, SolverModel, Variable};
 use rust_sbml::{Model, Parameter, Reaction, Species, SpeciesReference};
 
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ impl ModelLP {
     /// Add the constraints to th problem
     pub fn add_constraints<S: Solver>(&self, model: &mut S::Model) {
         for (_, cons) in self.stoichiometry.iter() {
-            model.add_constraint(constraint::eq(cons.iter().sum::<Expression>(), 0f32));
+            model.add_constraint(constraint::eq(cons.iter().sum::<Expression>(), 0.));
         }
     }
     fn add_vars(&mut self, problem: &mut ProblemVariables) {

--- a/tests/ecoli.rs
+++ b/tests/ecoli.rs
@@ -1,6 +1,7 @@
 extern crate kair;
 
-use kair::{Fbc, ModelLP};
+use good_lp::default_solver;
+use kair::{flux_analysis::fba, Fbc, ModelLP};
 use std::str::FromStr;
 
 const EXAMPLE: &str = include_str!("../tests/EcoliCore.xml");
@@ -41,7 +42,7 @@ fn verify_neg_bound() {
 fn optimize_ecoli() {
     let model = ModelLP::from_str(&EXAMPLE).unwrap();
     assert_eq!(
-        (model.optimize().unwrap()["R_BIOMASS_Ecoli_core_w_GAM_"] * 10000.).round() as i32,
+        (fba(model, default_solver).unwrap()["R_BIOMASS_Ecoli_core_w_GAM"] * 10000.).round() as i32,
         8739
     )
 }

--- a/tests/ecoli.rs
+++ b/tests/ecoli.rs
@@ -40,9 +40,9 @@ fn verify_neg_bound() {
 
 #[test]
 fn optimize_ecoli() {
-    let model = ModelLP::from_str(&EXAMPLE).unwrap();
+    let mut model = ModelLP::from_str(&EXAMPLE).unwrap();
     assert_eq!(
-        (fba(model, default_solver).unwrap()["R_BIOMASS_Ecoli_core_w_GAM"] * 10000.).round() as i32,
+        (fba(&mut model, default_solver).unwrap()["R_BIOMASS_Ecoli_core_w_GAM"] * 10000.).round() as i32,
         8739
     )
 }


### PR DESCRIPTION
### Description
[`good_lp`](https://github.com/rust-or/good_lp) is a [`lp-modeler`](https://github.com/rust-or/rust-lp-modeler) alternative.

#### Pros
* Faster. In the benchmark, wee see a 70% improvement on populating a model of 3741 variables and 5532 constraints.
* Removes a lot of macro complexity that `kair` is not benefiting from.

#### Cons
* Problems are not reusable: the `ModelLP` abstraction with the `lp-modeler` backend implements `LpProblem`, holding the internal Variable and Constraints variables. This is not the case of the `good_lp` backend, which forces `ModelLP` to generate variables and constraints on the fly everytime a LP is optimized. This is less convenient, but it is not inelegant (still faster anyways). 
* It may be easier to adapt to parallel processing but worse for algorithms that iteratively modify the constraints/objectives of a problem between solver calls (for the reason above).
* `good_lp` does not support integer variables, which are required by different COBRA algorithms, although they are not implemented right now.

![Benchmark](https://user-images.githubusercontent.com/46683255/111885714-c7e46d00-89c9-11eb-9196-c176cfafcf0a.png)

### Implementation
`ModelLP` is now a lean abstraction that provides methods for populating `good_lp::ProblemVariables` and adding constraints to `good_lp::solver::Solver::Model` with the SBML information from [`rust_sbml`](https://github.com/carrascomj/rust_sbml).